### PR TITLE
Support specifying the default max number of iterations

### DIFF
--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -1,4 +1,4 @@
-/*global location*/
+/*global window*/
 // Copyright (c) 2016 Sune Simonsen <sune@we-knowhow.dk>
 //
 // Permission is hereby granted, free of charge, to any person
@@ -31,6 +31,16 @@
         root.weknowhow.unexpectedCheck = factory();
     }
 })(this, function () {
+    var defaultMaxIterations = 300;
+    if (typeof window !== 'undefined' && typeof window.location !== 'undefined') {
+        var m = window.location.search.match(/[?&]maxiterations=(\d+)(?:$|&)/);
+        if (m) {
+            defaultMaxIterations = parseInt(m[1], 10);
+        }
+    } else if (typeof process !== 'undefined' && process.env.UNEXPECTED_CHECK_MAX_ITERATIONS) {
+        defaultMaxIterations = parseInt(process.env.UNEXPECTED_CHECK_MAX_ITERATIONS, 10);
+    }
+
     return {
         name: 'unexpected-check',
         installInto: function (expect) {
@@ -52,7 +62,7 @@
 
             expect.addAssertion('<function> to be valid for all <object>', function (expect, subject, options) {
                 var generators = options.generators || [];
-                var maxIterations = options.maxIterations || 300;
+                var maxIterations = options.maxIterations || defaultMaxIterations;
                 var maxErrorIterations = options.maxErrorIterations || 1000;
                 var maxErrors = options.maxErrors || 20;
 


### PR DESCRIPTION
Either via the `UNEXPECTED_CHECK_MAX_ITERATIONS` environment variable
or the `maxiterations=...` GET parameter in the browser.

Fixes #2.

I've tested this manually. Sorry for not including automatic tests -- it would require either using proxyquire or something like the "external" tests we use in Unexpected, both of which would add a bit of complexity. Let me know if you think that's required.