### PR TITLE
Add 'when fuzzed by' helper assertion.

### DIFF
--- a/documentation/assertions/any/when-fuzzed-by.md
+++ b/documentation/assertions/any/when-fuzzed-by.md
@@ -32,28 +32,18 @@ expect('abc', 'when fuzzed by', makePrefixGenerator, 'to match', /^a/);
 ```
 
 ```output
-expected 'abc' when fuzzed by
-function makePrefixGenerator(str) {
-  return g.integer({
-    min: 0,
-    max: str.length - 1
-  }).map(function (prefixLength) {
-    return str.substr(0, prefixLength);
-  });
-} to match /^a/
-  Ran 2 iterations and found 1 errors
-  counterexample:
+Ran 2 iterations and found 1 errors
+counterexample:
 
-    Generated input: ''
+  Generated input: ''
+  with: fuzz('abc', function makePrefixGenerator(str) {
+    return g.integer({
+      min: 0,
+      max: str.length - 1
+    }).map(function (prefixLength) {
+      return str.substr(0, prefixLength);
+    });
+  })
 
-    expected 'abc' when fuzzed by
-    function makePrefixGenerator(str) {
-      return g.integer({
-        min: 0,
-        max: str.length - 1
-      }).map(function (prefixLength) {
-        return str.substr(0, prefixLength);
-      });
-    } to match /^a/
-      expected '' to match /^a/
+  expected '' to match /^a/
 ```

--- a/documentation/assertions/any/when-fuzzed-by.md
+++ b/documentation/assertions/any/when-fuzzed-by.md
@@ -34,7 +34,10 @@ expect('abc', 'when fuzzed by', makePrefixGenerator, 'to match', /^a/);
 ```output
 expected 'abc' when fuzzed by
 function makePrefixGenerator(str) {
-  return g.integer({min: 0, max: str.length - 1}).map(function (prefixLength) {
+  return g.integer({
+    min: 0,
+    max: str.length - 1
+  }).map(function (prefixLength) {
     return str.substr(0, prefixLength);
   });
 } to match /^a/
@@ -45,7 +48,10 @@ function makePrefixGenerator(str) {
 
     expected 'abc' when fuzzed by
     function makePrefixGenerator(str) {
-      return g.integer({min: 0, max: str.length - 1}).map(function (prefixLength) {
+      return g.integer({
+        min: 0,
+        max: str.length - 1
+      }).map(function (prefixLength) {
         return str.substr(0, prefixLength);
       });
     } to match /^a/

--- a/documentation/assertions/any/when-fuzzed-by.md
+++ b/documentation/assertions/any/when-fuzzed-by.md
@@ -1,0 +1,53 @@
+A shorthand for
+[the "to be valid for all" assertion](../../function/to-be-valid-for-all/) for
+simple cases where you have a test subject and a function that returns a
+generator that "fuzzes", or somehow creates test cases, based on the subject.
+
+```js
+var g = require('chance-generators')(666);
+
+function makePrefixGenerator(str) {
+    return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {
+        return str.substr(0, prefixLength);
+    });
+}
+
+expect('abc', 'when fuzzed by', makePrefixGenerator, 'to match', /^a/);
+```
+
+The above succeeds because the generated prefixes are at least one character
+long, so every generated string will start with 'a'. If we change the minimum
+prefix length to 0, we will see it generate the empty string fail:
+
+```js
+var g = require('chance-generators')(666);
+
+function makePrefixGenerator(str) {
+    return g.integer({min: 0, max: str.length - 1}).map(function (prefixLength) {
+        return str.substr(0, prefixLength);
+    });
+}
+
+expect('abc', 'when fuzzed by', makePrefixGenerator, 'to match', /^a/);
+```
+
+```output
+expected 'abc' when fuzzed by
+function makePrefixGenerator(str) {
+  return g.integer({min: 0, max: str.length - 1}).map(function (prefixLength) {
+    return str.substr(0, prefixLength);
+  });
+} to match /^a/
+  Ran 2 iterations and found 1 errors
+  counterexample:
+
+    Generated input: ''
+
+    expected 'abc' when fuzzed by
+    function makePrefixGenerator(str) {
+      return g.integer({min: 0, max: str.length - 1}).map(function (prefixLength) {
+        return str.substr(0, prefixLength);
+      });
+    } to match /^a/
+      expected '' to match /^a/
+```

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -181,6 +181,13 @@
                     generators: Array.prototype.slice.call(arguments, 2)
                 });
             });
+
+            expect.addAssertion('<any> [when] fuzzed by <function> <assertion>', function (expect, subject, generator) {
+                expect.errorMode = 'nested';
+                return expect(function (value) {
+                    return expect.shift(value);
+                }, 'to be valid for all', generator(subject));
+            });
         }
     };
 });

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -70,6 +70,21 @@
                 }
             });
 
+            expect.addType({
+                name: 'fuzzed-generator',
+                identify: function (value) {
+                    return value && value.isFuzzedGenerator;
+                },
+                inspect: function (value, depth, output, inspect) {
+                    output.jsFunctionName('fuzz')
+                      .text('(')
+                      .appendItems(value.args, ', ')
+                      .text(', ')
+                      .appendInspected(value.mutatorFunction)
+                      .text(')');
+                }
+            });
+
             var promiseLoop = function (condition, action) {
                 return expect.promise(function (resolve, reject) {
                     var loop = function () {
@@ -182,11 +197,32 @@
                 });
             });
 
-            expect.addAssertion('<any> [when] fuzzed by <function> <assertion>', function (expect, subject, generator) {
-                expect.errorMode = 'nested';
+            function fuzzedGenerator(input, mutator, mutationGenerator) {
+                mutationGenerator = mutationGenerator || mutator(input);
+                var generator = function () {
+                    return mutationGenerator();
+                };
+
+                if (mutationGenerator.shrink) {
+                    generator.shrink = function (value) {
+                        return fuzzedGenerator(input, mutator, mutationGenerator.shrink(value));
+                    };
+                }
+
+                generator.isGenerator = true;
+                generator.isFuzzedGenerator = true;
+                generator.args = [input];
+                generator.mutatorFunction = mutator;
+
+                return generator;
+            }
+
+            expect.addAssertion('<any> [when] fuzzed by <function> <assertion>', function (expect, subject, mutator) {
+                expect.errorMode = 'bubble';
+
                 return expect(function (value) {
                     return expect.shift(value);
-                }, 'to be valid for all', generator(subject));
+                }, 'to be valid for all', fuzzedGenerator(subject, mutator));
             });
         }
     };

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "lodash.escape": "3.1.0",
     "lodash.unescape": "3.1.0",
     "mocha": "2.3.4",
+    "sinon": "^1.17.4",
     "unexpected": "10.13.3",
     "unexpected-documentation-site-generator": "^4.0.0",
     "unexpected-markdown": "^1.4.0",
+    "unexpected-sinon": "^10.2.1",
     "unexpected-stream": "2.0.3"
   }
 }

--- a/test/unexpected-check.spec.js
+++ b/test/unexpected-check.spec.js
@@ -233,25 +233,18 @@ describe('unexpected-check', function () {
                     });
                 }, 'to have length', 5);
             }, 'to error with',
-                "expected 'abcdef' when fuzzed by\n" +
-                "function prefixGenerator(str) {\n" +
-                "  return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {\n" +
-                "    return str.substr(0, prefixLength);\n" +
-                "  });\n" +
-                "} to have length 5\n" +
-                "  Ran 2 iterations and found 2 errors\n" +
-                "  counterexample:\n" +
+                "Ran 2 iterations and found 2 errors\n" +
+                "counterexample:\n" +
                 "\n" +
-                "    Generated input: 'a'\n" +
+                "  Generated input: 'a'\n" +
+                "  with: fuzz('abcdef', function prefixGenerator(str) {\n" +
+                "    return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {\n" +
+                "      return str.substr(0, prefixLength);\n" +
+                "    });\n" +
+                "  })\n" +
                 "\n" +
-                "    expected 'abcdef' when fuzzed by\n" +
-                "    function prefixGenerator(str) {\n" +
-                "      return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {\n" +
-                "        return str.substr(0, prefixLength);\n" +
-                "      });\n" +
-                "    } to have length 5\n" +
-                "      expected 'a' to have length 5\n" +
-                "        expected 1 to be 5"
+                "  expected 'a' to have length 5\n" +
+                "    expected 1 to be 5"
             );
         });
     });

--- a/test/unexpected-check.spec.js
+++ b/test/unexpected-check.spec.js
@@ -3,7 +3,8 @@ var Generators = require('chance-generators');
 var expect = require('unexpected');
 expect.output.preferredWidth = 80;
 
-expect.use(require('../lib/unexpected-check'));
+var sinon = require('sinon');
+expect.use(require('../lib/unexpected-check')).use(require('unexpected-sinon'));
 
 expect.addAssertion('<array> to be sorted', function (expect, subject) {
     var isSorted = subject.every(function (x, i) {
@@ -205,5 +206,53 @@ describe('unexpected-check', function () {
             'to inspect as',
             'n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 })).map(function (value) { return \'number: \' + value; })'
         );
+    });
+
+    describe('when fuzzed by assertion', function () {
+        it('should use the supplied function to make a generator from the subject and use the generator to make test cases', function () {
+            var fuzzer;
+
+            var prefixGenerator = sinon.spy(function prefixGenerator(str) {
+                fuzzer = sinon.spy(g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {
+                    return str.substr(0, prefixLength);
+                }));
+                return fuzzer;
+            });
+
+            return expect('abcdef', 'when fuzzed by', prefixGenerator, 'to be a string').then(function () {
+                expect(prefixGenerator, 'was called once');
+                expect(fuzzer, 'was called times', 300);
+            });
+        });
+
+        it('should error out with a counterexample', function () {
+            return expect(function () {
+                return expect('abcdef', 'when fuzzed by', function prefixGenerator(str) {
+                    return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {
+                        return str.substr(0, prefixLength);
+                    });
+                }, 'to have length', 5);
+            }, 'to error with',
+                "expected 'abcdef' when fuzzed by\n" +
+                "function prefixGenerator(str) {\n" +
+                "  return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {\n" +
+                "    return str.substr(0, prefixLength);\n" +
+                "  });\n" +
+                "} to have length 5\n" +
+                "  Ran 2 iterations and found 2 errors\n" +
+                "  counterexample:\n" +
+                "\n" +
+                "    Generated input: 'a'\n" +
+                "\n" +
+                "    expected 'abcdef' when fuzzed by\n" +
+                "    function prefixGenerator(str) {\n" +
+                "      return g.integer({min: 1, max: str.length - 1}).map(function (prefixLength) {\n" +
+                "        return str.substr(0, prefixLength);\n" +
+                "      });\n" +
+                "    } to have length 5\n" +
+                "      expected 'a' to have length 5\n" +
+                "        expected 1 to be 5"
+            );
+        });
     });
 });


### PR DESCRIPTION
I've found this more handy than `to be valid for all` in simple cases where there's a single input (subject) that has to be fuzzed and I don't need to change the default options. Let me know what you think :)