### PR TITLE
Print out the generators that was used to generated the failing input

### DIFF
--- a/documentation/assertions/function/to-be-valid-for-all.md
+++ b/documentation/assertions/function/to-be-valid-for-all.md
@@ -69,6 +69,7 @@ Ran 67 iterations and found 1 errors
 counterexample:
 
   Generated input: ''
+  with: string({ length: natural({ max: 200 }) })
 
   TypeError('Cannot read property \'forEach\' of null')
 ```

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -84,6 +84,7 @@ Ran 1000 iterations and found 14 errors
 counterexample:
 
   Generated input: [ 2, 10 ]
+  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 }))
 
   expected [ 10, 2 ] to be sorted
 ```
@@ -206,6 +207,7 @@ Ran 100 iterations and found 4 errors
 counterexample:
 
   Generated input: [ 0, -1, 4, 10 ]
+  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 }))
 
   expected [ -1, 0, 10, 4 ] to be sorted
 ```

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -44,6 +44,21 @@
     return {
         name: 'unexpected-check',
         installInto: function (expect) {
+            expect.addType({
+                name: 'chance-generator',
+                identify: function (value) {
+                    return value && value.isGenerator;
+                },
+                inspect: function (value, depth, output) {
+                    output.jsFunctionName(value.generatorName);
+                    if (value.args.length > 0) {
+                        output.text('(');
+                        output.appendItems(value.args, ', ');
+                        output.text(')');
+                    }
+                }
+            });
+
             var promiseLoop = function (condition, action) {
                 return expect.promise(function (resolve, reject) {
                     var loop = function () {
@@ -137,10 +152,11 @@
 
                             output.indentLines();
                             output.i().block(function (output) {
-                                output.text('Generated input: ').appendItems(bestFailure.args, ', ');
-                                output.nl(2).block(function (output) {
-                                    output.appendErrorMessage(bestFailure.error);
-                                });
+                                output.text('Generated input: ').appendItems(bestFailure.args, ', ').nl()
+                                  .text('with: ').appendItems(options.generators, ', ').nl(2)
+                                  .block(function (output) {
+                                      output.appendErrorMessage(bestFailure.error);
+                                  });
                             });
                         });
                     }

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -52,10 +52,21 @@
                 inspect: function (value, depth, output) {
                     output.jsFunctionName(value.generatorName);
                     if (value.args.length > 0) {
-                        output.text('(');
-                        output.appendItems(value.args, ', ');
-                        output.text(')');
+                        output.text('(').appendItems(value.args, ', ').text(')');
                     }
+                }
+            });
+
+            expect.addType({
+                name: 'mapped-chance-generator',
+                identify: function (value) {
+                    return value && value.isGenerator && value.isMappedGenerator;
+                },
+                inspect: function (value, depth, output, inspect) {
+                    output.appendInspected(value.parentGenerator)
+                      .text('.').jsFunctionName('map').text('(')
+                      .appendInspected(value.mapFunction)
+                      .text(')');
                 }
             });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Sune Simonsen",
   "license": "MIT",
   "devDependencies": {
-    "chance-generators": "1.15.2",
+    "chance-generators": "1.16.0",
     "eslint": "2.7.0",
     "eslint-config-onelint": "1.0.2",
     "lodash.escape": "3.1.0",

--- a/test/unexpected-check.spec.js
+++ b/test/unexpected-check.spec.js
@@ -44,6 +44,7 @@ describe('unexpected-check', function () {
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ -1, -2 ]\n' +
+               '  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 }))\n' +
                '\n' +
                '  expected [ -1, -2 ] to be sorted');
     });
@@ -58,6 +59,7 @@ describe('unexpected-check', function () {
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ 2 ]\n' +
+               '  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 }))\n' +
                '\n' +
                '  expected [ 2 ] not to contain 2\n' +
                '\n' +
@@ -85,6 +87,7 @@ describe('unexpected-check', function () {
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ 0 ], 0\n' +
+               '  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 })), integer({ min: -20, max: 20 })\n' +
                '\n' +
                '  expected [ 0 ] not to contain 0\n' +
                '\n' +
@@ -105,6 +108,7 @@ describe('unexpected-check', function () {
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ 0 ]\n' +
+               '  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 }))\n' +
                '\n' +
                '  expected [ 0 ]\n' +
                '  to have items satisfying function (item, i) { expect(item, \'not to be\', i); }\n' +
@@ -128,6 +132,7 @@ describe('unexpected-check', function () {
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ \')\' ]\n' +
+               '  with: n(string, integer({ min: 1, max: 20 }))\n' +
                '\n' +
                '  expected [ \')\' ] to have items satisfying\n' +
                '  function (item) {\n' +
@@ -154,6 +159,7 @@ describe('unexpected-check', function () {
             'counterexample:\n' +
             '\n' +
             '  Generated input: [ 0 ], 0\n' +
+            '  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 })), integer({ min: -20, max: 20 })\n' +
             '\n' +
             '  expected [ 0 ] not to contain 0\n' +
             '\n' +
@@ -178,6 +184,7 @@ describe('unexpected-check', function () {
             'counterexample:\n' +
             '\n' +
             '  Generated input: [ 0 ], 0\n' +
+            '  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 })), integer({ min: -20, max: 20 })\n' +
             '\n' +
             '  expected [ 0 ] not to contain 0\n' +
             '\n' +

--- a/test/unexpected-check.spec.js
+++ b/test/unexpected-check.spec.js
@@ -14,6 +14,10 @@ expect.addAssertion('<array> to be sorted', function (expect, subject) {
     expect(isSorted, 'to be true');
 });
 
+expect.addAssertion('<any> to inspect as <string>', function (expect, subject, value) {
+    expect(expect.inspect(subject).toString(), 'to equal', value);
+});
+
 function sort(arr, cmp) {
     return [].concat(arr).sort(cmp);
 }
@@ -191,5 +195,15 @@ describe('unexpected-check', function () {
             '  [\n' +
             '    0 // should be removed\n' +
             '  ]');
+    });
+
+    it('inspects mapped generators correctly', function () {
+        expect(
+            arrays.map(function (value) {
+                return 'number: ' + value;
+            }),
+            'to inspect as',
+            'n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 })).map(function (value) { return \'number: \' + value; })'
+        );
     });
 });


### PR DESCRIPTION
Now you will get error out that includes the generators that generated the failing input:

```
Ran 100 iterations and found 4 errors
counterexample:

  Generated input: [ 0, -1, 4, 10 ]
  with: n(integer({ min: -20, max: 20 }), integer({ min: 1, max: 20 }))

  expected [ -1, 0, 10, 4 ] to be sorted
```

May work poorly with generators that does not inspect well, like a normal function.