### PR TITLE
Report when the first error was found. 

### DIFF
--- a/documentation/assertions/any/when-fuzzed-by.md
+++ b/documentation/assertions/any/when-fuzzed-by.md
@@ -35,7 +35,7 @@ expect('abc', 'when fuzzed by', makePrefixGenerator, 'to match', /^a/);
 ```
 
 ```output
-Ran 2 iterations and found 1 errors
+Found an error after 2 iterations
 counterexample:
 
   Generated input: ''

--- a/documentation/assertions/function/to-be-valid-for-all.md
+++ b/documentation/assertions/function/to-be-valid-for-all.md
@@ -65,7 +65,7 @@ expect(function (text) {
 ```
 
 ```output
-Ran 67 iterations and found 1 errors
+Found an error after 67 iterations
 counterexample:
 
   Generated input: ''

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -80,7 +80,7 @@ But that assumption as actually not true as the build-in sort functions is based
 on converting items to strings and comparing them. So you will get the following error:
 
 ```output
-Ran 1001 iterations and found 110 errors
+Found an error after 1 iteration, 109 additional errors found.
 counterexample:
 
   Generated input: [ -1, -2 ]
@@ -202,7 +202,7 @@ expect(function (arr) {
 ```
 
 ```output
-Ran 101 iterations and found 9 errors
+Found an error after 1 iteration, 8 additional errors found.
 counterexample:
 
   Generated input: [ 10, 0, 0, 2 ]

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -185,7 +185,7 @@ return expect(function (text) {
   or setting the query parameter `maxiterations` in the browser.
 * `maxErrorIterations` (default 1000): the number of iterations unexpected-check
   can use to find a better error when an error occurs.
-* `maxErrors` (default 200): the number of found errors before stopping the input
+* `maxErrors` (default 201): the number of found errors before stopping the input
   shrinking process.
 
 ```js

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -230,7 +230,7 @@
 
                             if (execution.errors > 1) {
                                 output.error(',').sp().jsNumber(execution.errors - 1).sp()
-                                    .error('additional').sp().error(execution.errors > 1 ? 'errors' : 'error')
+                                    .error('additional').sp().error(execution.errors > 2 ? 'errors' : 'error')
                                     .sp().error('found.');
                             }
 

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -105,7 +105,7 @@
                 var generators = options.generators || [];
                 var maxIterations = options.maxIterations || defaultMaxIterations;
                 var maxErrorIterations = options.maxErrorIterations || 1000;
-                var maxErrors = options.maxErrors || 200;
+                var maxErrors = options.maxErrors || 201;
                 var interestingInputs = {};
                 var hasInstrumentation = !!global.recordLocation;
 
@@ -127,7 +127,7 @@
                     });
                 }
 
-                function createTasks() {
+                function runTasks() {
                     var tasks = [];
                     var errors = 0;
                     var i = 0;
@@ -206,12 +206,17 @@
                             errors++;
                         });
                     }).then(function () {
-                        return tasks;
+                        return {
+                            tasks: tasks,
+                            iterations: i,
+                            errorIterations: j,
+                            errors: errors
+                        };
                     });
                 }
 
-                return createTasks().then(function (tasks) {
-                    var failedTasks = tasks.filter(function (task) {
+                return runTasks().then(function (execution) {
+                    var failedTasks = execution.tasks.filter(function (task) {
                         return task.error;
                     });
 
@@ -220,10 +225,16 @@
 
                         expect.errorMode = 'bubble';
                         expect.fail(function (output) {
-                            output.error('Ran ').jsNumber(tasks.length).sp()
-                                .error(tasks.length > 1 ? 'iterations' : 'iteration')
-                                .error(' and found ').jsNumber(failedTasks.length).error(' errors').nl()
-                                .error('counterexample:').nl(2);
+                            output.error('Found an error after').sp().jsNumber(execution.iterations).sp()
+                                .error(execution.iterations > 1 ? 'iterations' : 'iteration');
+
+                            if (execution.errors > 1) {
+                                output.error(',').sp().jsNumber(execution.errors - 1).sp()
+                                    .error('additional').sp().error(execution.errors > 1 ? 'errors' : 'error')
+                                    .sp().error('found.');
+                            }
+
+                            output.nl().jsComment('counterexample:').nl(2);
 
                             output.indentLines();
                             output.i().block(function (output) {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,6 +1,6 @@
 --reporter spec
 --recursive
 --check-leaks
---timeout 20000
+--timeout 60000
 --require ./bootstrap-unexpected-markdown.js
 --compilers md:unexpected-markdown

--- a/test/unexpected-check.spec.js
+++ b/test/unexpected-check.spec.js
@@ -45,7 +45,7 @@ describe('unexpected-check', function () {
                 maxErrors: 15
             });
         }, 'to throw',
-               'Ran 131 iterations and found 12 errors\n' +
+               'Found an error after 1 iteration, 11 additional errors found.\n' +
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ -1, -2 ]\n' +
@@ -60,7 +60,7 @@ describe('unexpected-check', function () {
                 expect(arr, 'not to contain', 2);
             }, 'to be valid for all', arrays);
         }, 'to throw',
-               'Ran 653 iterations and found 200 errors\n' +
+               'Found an error after 9 iterations, 200 additional errors found.\n' +
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ 2 ]\n' +
@@ -88,7 +88,7 @@ describe('unexpected-check', function () {
                 expect(items, 'not to contain', i);
             }, 'to be valid for all', arrays, g.integer({ min: -20, max: 20 }));
         }, 'to throw',
-               'Ran 8 iterations and found 7 errors\n' +
+               'Found an error after 1 iteration, 6 additional errors found.\n' +
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ 0 ], 0\n' +
@@ -109,7 +109,7 @@ describe('unexpected-check', function () {
                 });
             }, 'to be valid for all', arrays);
         }, 'to throw',
-               'Ran 20 iterations and found 7 errors\n' +
+               'Found an error after 8 iterations, 6 additional errors found.\n' +
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ 0 ]\n' +
@@ -133,7 +133,7 @@ describe('unexpected-check', function () {
                 });
             }, 'to be valid for all', arrays);
         }, 'to throw',
-               'Ran 253 iterations and found 200 errors\n' +
+               'Found an error after 1 iteration, 200 additional errors found.\n' +
                'counterexample:\n' +
                '\n' +
                '  Generated input: [ \'!\' ]\n' +
@@ -160,7 +160,7 @@ describe('unexpected-check', function () {
                 }).delay(1);
             }, 'to be valid for all', arrays, g.integer({ min: -20, max: 20 }))
         , 'to be rejected with',
-            'Ran 8 iterations and found 7 errors\n' +
+            'Found an error after 1 iteration, 6 additional errors found.\n' +
             'counterexample:\n' +
             '\n' +
             '  Generated input: [ 0 ], 0\n' +
@@ -185,7 +185,7 @@ describe('unexpected-check', function () {
                 }
             }, 'to be valid for all', arrays, g.integer({ min: -20, max: 20 }));
         }, 'to error',
-            'Ran 8 iterations and found 7 errors\n' +
+            'Found an error after 1 iteration, 6 additional errors found.\n' +
             'counterexample:\n' +
             '\n' +
             '  Generated input: [ 0 ], 0\n' +
@@ -233,7 +233,7 @@ describe('unexpected-check', function () {
                     });
                 }, 'to have length', 5);
             }, 'to error with',
-                "Ran 2 iterations and found 2 errors\n" +
+                "Found an error after 1 iteration, 1 additional error found.\n" +
                 "counterexample:\n" +
                 "\n" +
                 "  Generated input: 'a'\n" +


### PR DESCRIPTION
It is usually useful to know how many iterations was used before an error was
found instead of how many iterations was used altogether. That say something
about how easy the error was to find. We also report how many additional errors
we found in the shrinking process as that says something about how common this
error is.