### PR TITLE
Report the full stack when a non-Unexpected error is hit

### DIFF
--- a/documentation/assertions/function/to-be-valid-for-all.md
+++ b/documentation/assertions/function/to-be-valid-for-all.md
@@ -70,7 +70,9 @@ counterexample:
   Generated input: ''
   with: string({ min: 0, max: 200 })
 
-  TypeError('Cannot read property \'forEach\' of null')
+  TypeError: Cannot read property 'forEach' of null
+      at rleEncode (/path/to/file.js:x:y)
+      at /path/to/file.js:x:y)
 ```
 
 Something is failing for the empty string input. The problem is that the regular

--- a/documentation/assertions/function/to-be-valid-for-all.md
+++ b/documentation/assertions/function/to-be-valid-for-all.md
@@ -61,6 +61,8 @@ expect(text => {
 }, 'to be valid for all', string({ max: 200 }));
 ```
 
+<!-- unexpected-markdown cleanStackTrace: true -->
+
 ```output
 Found an error after 220 iterations
 counterexample:

--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -373,7 +373,11 @@
                   .appendItems(options.generators, ', ')
                   .nl(2)
                   .block(function(output) {
-                    output.appendErrorMessage(bestFailure.error);
+                    if (bestFailure.error.isUnexpected) {
+                      output.appendErrorMessage(bestFailure.error);
+                    } else {
+                      output.error(bestFailure.error.stack);
+                    }
                   });
               });
             });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^1.15.3",
     "serve": "^11.0.0",
     "unexpected": "^11.0.0",
-    "unexpected-documentation-site-generator": "^6.0.0",
+    "unexpected-documentation-site-generator": "^6.1.0",
     "unexpected-markdown": "^4.0.0",
     "unexpected-stream": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "serve": "^11.0.0",
     "unexpected": "^11.0.0",
     "unexpected-documentation-site-generator": "^6.1.0",
-    "unexpected-markdown": "^4.0.0",
+    "unexpected-markdown": "^4.1.1",
     "unexpected-stream": "^4.0.0"
   },
   "keywords": [


### PR DESCRIPTION
I managed to trigger a bug in subfont, but it was a bit tricky to find out what went wrong, because no stack trace was reported:

![subfont_error](https://user-images.githubusercontent.com/373545/68536951-ccbbfa00-035b-11ea-89e4-08d16bfc3d68.png)

I suggest that we report the full stack trace in that case.

Not sure why I had to change the expected number of iterations in another test after introducing a test for this. Should we also reset chance-generators before each test here?