### PR TITLE
Seed the generators in valid for all differently

### DIFF
--- a/lib/unexpected-check.js
+++ b/lib/unexpected-check.js
@@ -188,8 +188,9 @@
         var maxErrors = options.maxErrors || 201;
         var interestingInputs = {};
         var hasInstrumentation = !!global.recordLocation;
+        var seed = 42;
 
-        var iterators = generators.map(function(generator) {
+        var iterators = generators.map(function(generator, index) {
           if (!generator.values) {
             throw new Error(
               'Generators needs to have a values method that returns an iterator\n' +
@@ -197,12 +198,18 @@
             );
           }
 
-          return generator.values({ skipSeedCache: true });
+          return generator.values({
+            skipSeedCache: true,
+            seed: seed + index
+          });
         });
 
         function resetIterators() {
-          iterators = generators.map(function(generator) {
-            return generator.values({ skipSeedCache: true });
+          iterators = generators.map(function(generator, index) {
+            return generator.values({
+              skipSeedCache: true,
+              seed: seed + index
+            });
           });
         }
 

--- a/test/unexpected-check.spec.js
+++ b/test/unexpected-check.spec.js
@@ -181,7 +181,7 @@ describe('unexpected-check', function() {
         );
       },
       'to throw',
-      'Found an error after 3 iterations, 10 additional errors found.\n' +
+      'Found an error after 6 iterations, 14 additional errors found.\n' +
         'counterexample:\n' +
         '\n' +
         '  Generated input: [ 0 ], 0\n' +
@@ -277,7 +277,7 @@ describe('unexpected-check', function() {
         integer({ min: -20, max: 20 })
       ),
       'to be rejected with',
-      'Found an error after 3 iterations, 10 additional errors found.\n' +
+      'Found an error after 6 iterations, 14 additional errors found.\n' +
         'counterexample:\n' +
         '\n' +
         '  Generated input: [ 0 ], 0\n' +
@@ -312,7 +312,7 @@ describe('unexpected-check', function() {
         );
       },
       'to error',
-      'Found an error after 3 iterations, 10 additional errors found.\n' +
+      'Found an error after 6 iterations, 14 additional errors found.\n' +
         'counterexample:\n' +
         '\n' +
         '  Generated input: [ 0 ], 0\n' +
@@ -323,6 +323,16 @@ describe('unexpected-check', function() {
         '  [\n' +
         '    0 // should be removed\n' +
         '  ]'
+    );
+  });
+
+  it('seeds the given generators differently', () => {
+    expect(
+      (a, b) => {
+        expect(a, 'not to be', b);
+      },
+      'to be valid for all',
+      { generators: [integer, integer], maxIterations: 1 }
     );
   });
 


### PR DESCRIPTION
I unfortunately introduced a bug, when I isolated the randomness around the
`to be valid for all` assertion, where I started to skip the chance cache. The
problem was that is you were using the same generator twice, you would produce
the same values. That is obviously not what we want :-( - but this commit fixes
the problem.